### PR TITLE
feat(theme) Add theme configuration proto definitions

### DIFF
--- a/Untitled-1.txt
+++ b/Untitled-1.txt
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package automotive.design.v1;
+
+option java_multiple_files = true;
+option java_package = "com.google.automotive.design.v1";
+
+// Defines theme configuration for automotive UI components
+message ThemeConfiguration {
+  // Color scheme mode
+  enum ColorMode {
+    COLOR_MODE_UNSPECIFIED = 0;
+    LIGHT = 1;
+    DARK = 2;
+    AUTO = 3;  // System default
+  }
+
+  // Dynamic color generation options
+  message DynamicColorOptions {
+    bool enabled = 1;
+    // Source color for dynamic palette generation
+    message SourceColor {
+      int32 red = 1;
+      int32 green = 2;
+      int32 blue = 3;
+    }
+    SourceColor source_color = 2;
+    // Harmony rules for generating color variations
+    enum ColorHarmony {
+      HARMONY_UNSPECIFIED = 0;
+      ANALOGOUS = 1;
+      COMPLEMENTARY = 2;
+      TRIADIC = 3;
+    }
+    ColorHarmony harmony_type = 3;
+  }
+
+  // Theme configuration properties
+  ColorMode color_mode = 1;
+  DynamicColorOptions dynamic_colors = 2;
+  
+  // Theme variants for different contexts
+  enum ThemeVariant {
+    VARIANT_UNSPECIFIED = 0;
+    DEFAULT = 1;
+    HIGH_CONTRAST = 2;
+    ENERGY_SAVER = 3;  // Optimized for OLED displays
+  }
+  ThemeVariant variant = 3;
+}

--- a/live_update/android_interface.proto
+++ b/live_update/android_interface.proto
@@ -13,14 +13,55 @@
 // limitations under the License.
 
 syntax = "proto3";
-package designcompose.live_update;
 
-import "definition/design_compose_definition.proto";
-import "live_update/figma/figma_doc.proto";
+package automotive.design.v1;
 
 option java_multiple_files = true;
-option java_package = "com.android.designcompose.live_update";
-option optimize_for = LITE_RUNTIME;
+option java_package = "com.google.automotive.design.v1";
+
+// Defines theme configuration for automotive UI components
+message ThemeConfiguration {
+  // Color scheme mode
+  enum ColorMode {
+    COLOR_MODE_UNSPECIFIED = 0;
+    LIGHT = 1;
+    DARK = 2;
+    AUTO = 3;  // System default
+  }
+
+  // Dynamic color generation options
+  message DynamicColorOptions {
+    bool enabled = 1;
+    // Source color for dynamic palette generation
+    message SourceColor {
+      int32 red = 1;
+      int32 green = 2;
+      int32 blue = 3;
+    }
+    SourceColor source_color = 2;
+    // Harmony rules for generating color variations
+    enum ColorHarmony {
+      HARMONY_UNSPECIFIED = 0;
+      ANALOGOUS = 1;
+      COMPLEMENTARY = 2;
+      TRIADIC = 3;
+    }
+    ColorHarmony harmony_type = 3;
+  }
+
+  // Theme configuration properties
+  ColorMode color_mode = 1;
+  DynamicColorOptions dynamic_colors = 2;
+  
+  // Theme variants for different contexts
+  enum ThemeVariant {
+    VARIANT_UNSPECIFIED = 0;
+    DEFAULT = 1;
+    HIGH_CONTRAST = 2;
+    ENERGY_SAVER = 3;  // Optimized for OLED displays
+  }
+  ThemeVariant variant = 3;
+}
 
 // From Kotlin to Rust
 message ConvertRequest {
@@ -61,4 +102,30 @@ message ConvertResponse {
     Document document = 1;
     string unmodified = 2;
   }
+}
+
+// Sample Kotlin code for creating a default theme configuration
+package com.google.automotive.design.examples
+
+import com.google.automotive.design.v1.ThemeConfiguration
+import com.google.automotive.design.v1.ThemeConfiguration.*
+
+fun createDefaultThemeConfig(): ThemeConfiguration {
+    return ThemeConfiguration.newBuilder()
+        .setColorMode(ColorMode.AUTO)
+        .setDynamicColors(
+            DynamicColorOptions.newBuilder()
+                .setEnabled(true)
+                .setSourceColor(
+                    DynamicColorOptions.SourceColor.newBuilder()
+                        .setRed(33)
+                        .setGreen(150)
+                        .setBlue(243)
+                        .build()
+                )
+                .setHarmonyType(DynamicColorOptions.ColorHarmony.ANALOGOUS)
+                .build()
+        )
+        .setVariant(ThemeVariant.DEFAULT)
+        .build()
 }

--- a/package com.google.automotive.design.exa
+++ b/package com.google.automotive.design.exa
@@ -1,0 +1,24 @@
+package com.google.automotive.design.examples
+
+import com.google.automotive.design.v1.ThemeConfiguration
+import com.google.automotive.design.v1.ThemeConfiguration.*
+
+fun createDefaultThemeConfig(): ThemeConfiguration {
+    return ThemeConfiguration.newBuilder()
+        .setColorMode(ColorMode.AUTO)
+        .setDynamicColors(
+            DynamicColorOptions.newBuilder()
+                .setEnabled(true)
+                .setSourceColor(
+                    DynamicColorOptions.SourceColor.newBuilder()
+                        .setRed(33)
+                        .setGreen(150)
+                        .setBlue(243)
+                        .build()
+                )
+                .setHarmonyType(DynamicColorOptions.ColorHarmony.ANALOGOUS)
+                .build()
+        )
+        .setVariant(ThemeVariant.DEFAULT)
+        .build()
+}


### PR DESCRIPTION
add proto defs for theme config with light and dark mode support, dynamic color generation, theme variants for different contexts and a kotlin example impl, makes theming consistent across auto ui with proper type safety and standardization