### PR TITLE
Support custom keyframe data and animation specs

### DIFF
--- a/definition/animation/animationspec.proto
+++ b/definition/animation/animationspec.proto
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/definition/animation/animationspec.proto
+++ b/definition/animation/animationspec.proto
@@ -1,0 +1,102 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+
+package designcompose.definition.animation;
+
+// Animation specification.
+message AnimationSpec {
+    optional google.protobuf.Duration initial_delay = 1;
+    Animations animation = 2;
+    optional StopType interrupt_type = 3;
+    map<string, string> custom_keyframe_data = 4;
+}
+
+// Specifies how to interrupt in-progress animations.
+message StopType {
+    oneof type {
+        google.protobuf.Empty reset_to_start = 1;
+        google.protobuf.Empty complete = 2;
+        float complete_with_progress = 3;
+        google.protobuf.Empty stop = 4;
+    }
+}
+
+// Animation types
+message Animations {
+    oneof type {
+        SmoothAnimation smooth = 1;
+        KeyFrameAnimation key_frame = 2;
+    }
+}
+
+// A smooth animation.
+message SmoothAnimation {
+    google.protobuf.Duration duration = 1;
+    RepeatType repeat_type = 2;
+    Easing easing = 3;
+}
+
+// Animation consist of key frames.
+message KeyFrameAnimation {
+    repeated KeyFrame steps = 1;
+    RepeatType repeat_type = 2;
+}
+
+// Specifies the animation repeat type.
+message RepeatType {
+    oneof type {
+        google.protobuf.Empty no_repeat = 1;
+        uint32 repeat = 2;
+        google.protobuf.Empty loop_forever = 3;
+    }
+}
+
+// A key frame in a key frame animation.
+message KeyFrame {
+    float value = 1;
+    google.protobuf.Duration duration = 2;
+}
+
+// Configures the animation easing curve.
+message Easing {
+    oneof type {
+        google.protobuf.Empty linear = 1;
+        BezierCurve bezier = 2;
+    }
+}
+
+// A Bezier curve
+message BezierCurve {
+    float p0 = 1;
+    float p1 = 2;
+    float p2 = 3;
+    float p3 = 4;
+}
+
+// The main override type.
+// - no_override: to use the default
+// - disable_animations: to disregard any default animations
+// - custom: specify a custom AnimationSpec
+message AnimationOverride {
+    oneof animation_override {
+        google.protobuf.Empty no_override = 1;
+        google.protobuf.Empty disable_animations = 2;
+        AnimationSpec custom = 3;
+    }
+}

--- a/definition/view/node_style.proto
+++ b/definition/view/node_style.proto
@@ -47,7 +47,7 @@ enum Display {
 
 // Contains all of the styleable parameters accepted by the Rect and Text
 // components.
-// Next id = 46
+// Next id = 47
 message NodeStyle {
   // Text properties
   element.Background text_color = 1[deprecated = true];
@@ -108,5 +108,5 @@ message NodeStyle {
   optional element.ShaderData shader_data = 43;
 
   optional element.ScalableUIData scalable_data = 44;
-  optional animation.AnimationOverride animation_override = 45;
+  optional animation.AnimationOverride animation_override = 46;
 }

--- a/definition/view/node_style.proto
+++ b/definition/view/node_style.proto
@@ -32,6 +32,7 @@ import "definition/modifier/matrix_transform.proto";
 import "definition/modifier/shadow.proto";
 import "definition/modifier/text.proto";
 import "definition/plugin/meter_data.proto";
+import "definition/animation/animationspec.proto";
 
 option java_multiple_files = true;
 option java_package = "com.android.designcompose.definition.view";
@@ -107,4 +108,5 @@ message NodeStyle {
   optional element.ShaderData shader_data = 43;
 
   optional element.ScalableUIData scalable_data = 44;
+  optional animation.AnimationOverride animation_override = 46;
 }

--- a/definition/view/node_style.proto
+++ b/definition/view/node_style.proto
@@ -108,5 +108,5 @@ message NodeStyle {
   optional element.ShaderData shader_data = 43;
 
   optional element.ScalableUIData scalable_data = 44;
-  optional animation.AnimationOverride animation_override = 46;
+  optional animation.AnimationOverride animation_override = 45;
 }


### PR DESCRIPTION
This PR introduces proto support for passing custom keyframe data and animation specifications from Figma into Squoosh. 

## Summary of Changes

* **Added animationspec.proto**: Introduces a new proto definition that supports rich animation features, including:
  * AnimationSpec: Specifies initial_delay, repeat behavior, interrupt types, and custom_keyframe_data via a string map.
  * Animations: Supports smooth animations (with duration, easing, and repeats) and keyframe animations.
  * StopType: Configures how to interrupt in-progress animations (reset_to_start, complete, complete_with_progress, stop).
  * Easing: Supports linear definitions or custom bezier curves.
  * AnimationOverride: Allows enabling/disabling or providing custom AnimationSpec overrides.
* **Updated node_style.proto**: 
  * Imports animationspec.proto and adds an animation_override field to the NodeStyle message.